### PR TITLE
calculate release hash

### DIFF
--- a/b/models.py
+++ b/b/models.py
@@ -108,6 +108,7 @@ class Release(models.Model):
     title = models.CharField(verbose_name='Название', max_length=250)
     date = models.DateField(verbose_name='Дата из мира игр', unique=True)
     updated_at = models.DateTimeField(verbose_name='Дата последнего изменения', auto_now=True)
+    hash = models.IntegerField(verbose_name="Hash of ratings in this release")
     class Meta:
         db_table = 'release'
 

--- a/manage.py
+++ b/manage.py
@@ -2,6 +2,9 @@
 """Django's command-line utility for administrative tasks."""
 import os
 import sys
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytz==2021.3
 six==1.16.0
 sqlparse==0.4.2
 python-dotenv==1.0.0
+mmh3==3.1.0

--- a/scripts/changes.py
+++ b/scripts/changes.py
@@ -1,0 +1,20 @@
+import mmh3
+import numpy as np
+
+
+def calculate_hash(players, teams, tournaments):
+    tournaments_to_concat = [t.data['score_real'].values for t in tournaments]
+    if tournaments_to_concat:
+        tournament_ratings = np.concatenate(tournaments_to_concat)
+    else:
+        tournament_ratings = np.array([])
+    tournament_ratings.sort()
+
+    player_ratings = players.data['rating'].values
+    player_ratings.sort()
+
+    team_ratings = teams.data['rating'].values
+    team_ratings.sort()
+
+    ratings_to_hash = np.concatenate((player_ratings, team_ratings, tournament_ratings))
+    return mmh3.hash_from_buffer(ratings_to_hash)


### PR DESCRIPTION
Combine rating bonuses from tournaments, teams, and players, and calculate a murmurhash of them. Don’t update Release’s `update_at` if hash (i.e., all bonuses in this release) stayed the same. However, we are still updating all values in the database.