### PR TITLE
update dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10.8
+          python-version: 3.11.6
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.10-slim-buster
+ARG PYTHON_VERSION=3.11-slim-buster
 
 FROM python:${PYTHON_VERSION}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ asgiref==3.4.1
 Django==3.2.23
 pandas==1.5.3
 postgres==4.0
-psycopg2-binary==2.9.6
+psycopg2-binary==2.9.9
 psycopg2-pool==1.1
 python-dateutil==2.8.2
 pytz==2021.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ psycopg2-pool==1.1
 python-dateutil==2.8.2
 pytz==2021.3
 six==1.16.0
-sqlparse==0.4.2
+sqlparse==0.4.4
 python-dotenv==1.0.0
 mmh3==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ postgres==4.0
 psycopg2-binary==2.9.9
 psycopg2-pool==1.1
 python-dateutil==2.8.2
-pytz==2021.3
+pytz==2023.3.post1
 six==1.16.0
 sqlparse==0.4.4
 python-dotenv==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-asgiref==3.4.1
+asgiref==3.7.2
 Django==3.2.23
 pandas==1.5.3
 postgres==4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.4.1
 Django==3.2.8
-pandas==1.3.5
+pandas==1.5.3
 postgres==4.0
 psycopg2-binary==2.9.6
 psycopg2-pool==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asgiref==3.4.1
-Django==3.2.8
+Django==3.2.23
 pandas==1.5.3
 postgres==4.0
 psycopg2-binary==2.9.6

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,6 +1,9 @@
 import unittest
 from datetime import date
 
+from dotenv import load_dotenv
+load_dotenv()
+
 import django
 django.setup()
 
@@ -12,5 +15,18 @@ class TestReleases(unittest.TestCase):
     def test_calc_single_release(self):
         release_date = date(2021, 9, 16)
         calc_release(release_date)
-        release = models.Release.objects.get(date=release_date)
-        self.assertEqual(201835736, release.hash)
+
+        team_at_first_place = models.Team_rating.objects.filter(release=2).order_by("place")[0]
+        self.assertEqual(45556, team_at_first_place.team_id)
+        self.assertEqual(10674, team_at_first_place.rating)
+        self.assertEqual(21, team_at_first_place.rating_change)
+
+        team_at_place_53 = models.Team_rating.objects.filter(release=2).order_by("place")[52]
+        self.assertEqual(50186, team_at_place_53.team_id)
+        self.assertEqual(7697, team_at_place_53.rating)
+        self.assertEqual(-189, team_at_place_53.rating_change)
+
+        team_at_place_400 = models.Team_rating.objects.filter(release=2).order_by("place")[399]
+        self.assertEqual(46627, team_at_place_400.team_id)
+        self.assertEqual(5288, team_at_place_400.rating)
+        self.assertEqual(0, team_at_place_400.rating_change)


### PR DESCRIPTION
Switches Python version to 3.11.
Minor bumps in libraries (Django and pandas major upgrades to be done in an another PR).
Reworks the release test to compare specific rating values instead of a release’s hash (which is flaky for now and needs to be fixed separately).