### PR TITLE
 move all query building into fast_insert

### DIFF
--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+SCHEMA_NAME = 'b'
 J = 0.99
 N_BEST_TOURNAMENTS_FOR_PLAYER_RATING = 7
 MAX_BONUS = 2300  # А.3.4

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -12,32 +12,36 @@ from b.models import Team_rating, Tournament_in_release, Player_rating_by_tourna
 
 
 class TestReleases(unittest.TestCase):
-    def test_calc_single_release(self):
+    @classmethod
+    def setUpClass(cls):
         release_date = date(2021, 9, 16)
         calc_release(release_date)
 
-        team_at_first_place = Team_rating.objects.filter(release=2).order_by("place")[0]
+    def test_team_rating_values(self):
+        team_at_first_place = Team_rating.objects.filter(release=3).order_by("place")[0]
         self.assertEqual(45556, team_at_first_place.team_id)
-        self.assertEqual(10674, team_at_first_place.rating)
-        self.assertEqual(21, team_at_first_place.rating_change)
+        self.assertEqual(10737, team_at_first_place.rating)
+        self.assertEqual(63, team_at_first_place.rating_change)
 
-        team_at_place_53 = Team_rating.objects.filter(release=2).order_by("place")[52]
-        self.assertEqual(50186, team_at_place_53.team_id)
-        self.assertEqual(7697, team_at_place_53.rating)
-        self.assertEqual(-189, team_at_place_53.rating_change)
+        team_at_place_57 = Team_rating.objects.filter(release=3).order_by("place")[56]
+        self.assertEqual(65268, team_at_place_57.team_id)
+        self.assertEqual(7653, team_at_place_57.rating)
+        self.assertEqual(-82, team_at_place_57.rating_change)
 
-        team_at_place_400 = Team_rating.objects.filter(release=2).order_by("place")[399]
+        team_at_place_400 = Team_rating.objects.filter(release=3).order_by("place")[399]
         self.assertEqual(46627, team_at_place_400.team_id)
         self.assertEqual(5288, team_at_place_400.rating)
         self.assertEqual(0, team_at_place_400.rating_change)
 
-        tournaments_in_release = Tournament_in_release.objects.filter(release=2)
-        self.assertEqual([6560, 6639, 7086, 7182, 7513],
+    def test_tournaments_in_release_values(self):
+        tournaments_in_release = Tournament_in_release.objects.filter(release=3)
+        self.assertEqual([6044, 6114, 7225, 7325],
                          list(tournaments_in_release.values_list('tournament_id', flat=True)))
 
-        players_in_release = Player_rating_by_tournament.objects.filter(release=2)
-        self.assertEqual(2264, players_in_release.get(player_id=80897, tournament_id=6639).cur_score)
-        self.assertEqual(2264, players_in_release.get(player_id=80897, tournament_id=6639).initial_score)
-        self.assertEqual(1767, players_in_release.get(player_id=80897, tournament_id=6076).cur_score)
-        self.assertEqual(1934, players_in_release.get(player_id=80897, tournament_id=6076).initial_score)
-        self.assertEqual(9, players_in_release.get(player_id=80897, tournament_id=6076).weeks_since_tournament)
+    def test_player_rating_by_tournament_values(self):
+        players_in_release = Player_rating_by_tournament.objects.filter(release=3)
+        self.assertEqual(1794, players_in_release.get(player_id=77673, tournament_id=7225).cur_score)
+        self.assertEqual(1794, players_in_release.get(player_id=77673, tournament_id=7225).initial_score)
+        self.assertEqual(1933, players_in_release.get(player_id=77673, tournament_id=5923).cur_score)
+        self.assertEqual(2053, players_in_release.get(player_id=77673, tournament_id=5923).initial_score)
+        self.assertEqual(6, players_in_release.get(player_id=77673, tournament_id=5923).weeks_since_tournament)

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -8,7 +8,7 @@ import django
 django.setup()
 
 from scripts.main import calc_release
-from b.models import Team_rating, Tournament_in_release, Player_rating_by_tournament
+from b.models import Team_rating, Tournament_in_release, Player_rating_by_tournament, Player_rating, Tournament_result
 
 
 class TestReleases(unittest.TestCase):
@@ -22,26 +22,79 @@ class TestReleases(unittest.TestCase):
         self.assertEqual(45556, team_at_first_place.team_id)
         self.assertEqual(10737, team_at_first_place.rating)
         self.assertEqual(63, team_at_first_place.rating_change)
+        self.assertEqual(9394, team_at_first_place.trb)
+        self.assertEqual(1, team_at_first_place.place)
+        self.assertEqual(0, team_at_first_place.place_change)
 
         team_at_place_57 = Team_rating.objects.filter(release=3).order_by("place")[56]
         self.assertEqual(65268, team_at_place_57.team_id)
         self.assertEqual(7653, team_at_place_57.rating)
         self.assertEqual(-82, team_at_place_57.rating_change)
+        self.assertEqual(7962, team_at_place_57.trb)
+        self.assertEqual(8, team_at_place_57.place_change)
+        self.assertEqual(57, team_at_place_57.place)
 
         team_at_place_400 = Team_rating.objects.filter(release=3).order_by("place")[399]
         self.assertEqual(46627, team_at_place_400.team_id)
         self.assertEqual(5288, team_at_place_400.rating)
         self.assertEqual(0, team_at_place_400.rating_change)
+        self.assertEqual(0, team_at_place_400.trb)
+        self.assertEqual(0, team_at_place_400.place_change)
+        self.assertEqual(400, team_at_place_400.place)
 
     def test_tournaments_in_release_values(self):
         tournaments_in_release = Tournament_in_release.objects.filter(release=3)
         self.assertEqual([6044, 6114, 7225, 7325],
                          list(tournaments_in_release.values_list('tournament_id', flat=True)))
 
+    def test_player_rating_values(self):
+        player_rating = Player_rating.objects.get(release=3, player_id=77673)
+        self.assertEqual(12434, player_rating.rating)
+        self.assertEqual(33, player_rating.rating_change)
+
+    def test_missing_player_rating_values(self):
+        self.assertEqual(0, Player_rating.objects.filter(release=3, player_id=100000).count())
+
     def test_player_rating_by_tournament_values(self):
-        players_in_release = Player_rating_by_tournament.objects.filter(release=3)
-        self.assertEqual(1794, players_in_release.get(player_id=77673, tournament_id=7225).cur_score)
-        self.assertEqual(1794, players_in_release.get(player_id=77673, tournament_id=7225).initial_score)
-        self.assertEqual(1933, players_in_release.get(player_id=77673, tournament_id=5923).cur_score)
-        self.assertEqual(2053, players_in_release.get(player_id=77673, tournament_id=5923).initial_score)
-        self.assertEqual(6, players_in_release.get(player_id=77673, tournament_id=5923).weeks_since_tournament)
+        player_top_bonuses = Player_rating_by_tournament.objects.filter(release=3, player_id=77673)
+        self.assertEqual(7, player_top_bonuses.count())
+
+        self.assertEqual(1794, player_top_bonuses.get(tournament_id=7225).cur_score)
+        self.assertEqual(1794, player_top_bonuses.get(tournament_id=7225).initial_score)
+        self.assertEqual(0, player_top_bonuses.get(tournament_id=7225).weeks_since_tournament)
+
+        self.assertEqual(1933, player_top_bonuses.get(tournament_id=5923).cur_score)
+        self.assertEqual(2053, player_top_bonuses.get(tournament_id=5923).initial_score)
+        self.assertEqual(6, player_top_bonuses.get(tournament_id=5923).weeks_since_tournament)
+
+    def test_tournament_result_values(self):
+        tournament_results = Tournament_result.objects.filter(tournament_id=7225)
+        self.assertEqual(95, tournament_results.count())
+
+        first_place = tournament_results.order_by("m")[0]
+        self.assertEqual(1, first_place.m)
+        self.assertEqual(1, first_place.mp)
+        self.assertEqual(49804, first_place.team_id)
+        self.assertEqual(2079, first_place.rating)
+        self.assertEqual(79, first_place.rating_change)
+        self.assertEqual(2079, first_place.bp)
+        self.assertEqual(0, first_place.d1)
+        self.assertEqual(160, first_place.d2)
+        self.assertEqual(9568, first_place.rg)
+        self.assertEqual(9568, first_place.rt)
+        self.assertEqual(0, first_place.r)
+        self.assertEqual(False, first_place.is_in_maii_rating)
+
+        # We want to find a specific team around the 20th place instead of fighting ORDER BY randomness
+        place_20 = tournament_results.get(team_id=43417)
+        self.assertEqual(19.5, place_20.m)
+        self.assertEqual(11, place_20.mp)
+        self.assertEqual(1380, place_20.rating)
+        self.assertEqual(-27, place_20.rating_change)
+        self.assertEqual(1532, place_20.bp)
+        self.assertEqual(-76, place_20.d1)
+        self.assertEqual(22, place_20.d2)
+        self.assertEqual(6821, place_20.rg)
+        self.assertEqual(7127, place_20.rt)
+        self.assertEqual(6954, place_20.r)
+        self.assertEqual(True, place_20.is_in_maii_rating)

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -8,7 +8,8 @@ import django
 django.setup()
 
 from scripts.main import calc_release
-from b.models import Team_rating, Tournament_in_release, Player_rating_by_tournament, Player_rating, Tournament_result
+from b.models import (Team_rating, Tournament_in_release, Player_rating_by_tournament,
+                      Player_rating, Tournament_result, Release)
 
 
 class TestReleases(unittest.TestCase):
@@ -16,9 +17,10 @@ class TestReleases(unittest.TestCase):
     def setUpClass(cls):
         release_date = date(2021, 9, 16)
         calc_release(release_date)
+        cls.release = Release.objects.get(date=release_date)
 
     def test_team_rating_values(self):
-        team_at_first_place = Team_rating.objects.filter(release=3).order_by("place")[0]
+        team_at_first_place = Team_rating.objects.filter(release=self.release).order_by("place")[0]
         self.assertEqual(45556, team_at_first_place.team_id)
         self.assertEqual(10737, team_at_first_place.rating)
         self.assertEqual(63, team_at_first_place.rating_change)
@@ -26,7 +28,7 @@ class TestReleases(unittest.TestCase):
         self.assertEqual(1, team_at_first_place.place)
         self.assertEqual(0, team_at_first_place.place_change)
 
-        team_at_place_57 = Team_rating.objects.filter(release=3).order_by("place")[56]
+        team_at_place_57 = Team_rating.objects.filter(release=self.release).order_by("place")[56]
         self.assertEqual(65268, team_at_place_57.team_id)
         self.assertEqual(7653, team_at_place_57.rating)
         self.assertEqual(-82, team_at_place_57.rating_change)
@@ -34,7 +36,7 @@ class TestReleases(unittest.TestCase):
         self.assertEqual(8, team_at_place_57.place_change)
         self.assertEqual(57, team_at_place_57.place)
 
-        team_at_place_400 = Team_rating.objects.filter(release=3).order_by("place")[399]
+        team_at_place_400 = Team_rating.objects.filter(release=self.release).order_by("place")[399]
         self.assertEqual(46627, team_at_place_400.team_id)
         self.assertEqual(5288, team_at_place_400.rating)
         self.assertEqual(0, team_at_place_400.rating_change)
@@ -43,20 +45,20 @@ class TestReleases(unittest.TestCase):
         self.assertEqual(400, team_at_place_400.place)
 
     def test_tournaments_in_release_values(self):
-        tournaments_in_release = Tournament_in_release.objects.filter(release=3)
+        tournaments_in_release = Tournament_in_release.objects.filter(release=self.release)
         self.assertEqual([6044, 6114, 7225, 7325],
                          list(tournaments_in_release.values_list('tournament_id', flat=True)))
 
     def test_player_rating_values(self):
-        player_rating = Player_rating.objects.get(release=3, player_id=77673)
+        player_rating = Player_rating.objects.get(release=self.release, player_id=77673)
         self.assertEqual(12434, player_rating.rating)
         self.assertEqual(33, player_rating.rating_change)
 
     def test_missing_player_rating_values(self):
-        self.assertEqual(0, Player_rating.objects.filter(release=3, player_id=100000).count())
+        self.assertEqual(0, Player_rating.objects.filter(release=self.release, player_id=100000).count())
 
     def test_player_rating_by_tournament_values(self):
-        player_top_bonuses = Player_rating_by_tournament.objects.filter(release=3, player_id=77673)
+        player_top_bonuses = Player_rating_by_tournament.objects.filter(release=self.release, player_id=77673)
         self.assertEqual(7, player_top_bonuses.count())
 
         self.assertEqual(1794, player_top_bonuses.get(tournament_id=7225).cur_score)

--- a/tests/trim.sql
+++ b/tests/trim.sql
@@ -52,6 +52,7 @@ delete from tournaments
 where id not in (6560, 6639, 7086, 7182, 7513, 6044, 6114, 7225, 7325);
 
 delete from base_rosters
-where season_id != 56;
+where season_id not in (53, 56);
 
 delete from b.release where id > 2;
+alter sequence b."b.release_details_id_seq" restart with 3;


### PR DESCRIPTION
All query building should happen in `fast_insert`.
String concatenation for insertion queries is the same for all tables, and we can infer the list of columns from the dictionaries provided.
This makes the shape of objects we write more explicit and the overall flow more readable.

We also now write to all tables change in a release calculation in a single transaction: if one insertion fails, we will roll back to a state before this recalculation instead of having a mishmash of updated and old values.

To ensure that we continue writing the same values, this PR adds tests for (some) values in all tables that we `fast_insert` into.