### PR TITLE
upgrade to pandas 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.7.2
 Django==3.2.23
-pandas==1.5.3
+pandas==2.1.4
 psycopg2-binary==2.9.9
 psycopg2-pool==1.1
 python-dateutil==2.8.2

--- a/scripts/teams.py
+++ b/scripts/teams.py
@@ -60,6 +60,7 @@ class TeamRating:
     # TODO: add a separate test for this!
     def update_ratings_for_changed_teams(self, changed_teams) -> List[Tuple[int, int]]:
         existing_teams = [t for t in changed_teams if t in set(self.data.index)]
+        self.data['rating'] = self.data['rating'].astype('float64')
         self.data['old_release_rating'] = self.data['rating']
         self.data.loc[existing_teams, 'rating'] = np.maximum(
             self.data.loc[existing_teams, 'rating'],

--- a/scripts/tournament.py
+++ b/scripts/tournament.py
@@ -100,7 +100,7 @@ class Tournament:
         self.data['score_real'] = tools.calc_score_real(self.data.score_pred.values, self.data.position.values)
         self.data['D1'] = self.calc_d1()
         self.data['D2'] = D2_MULTIPLIER * np.exp((self.data.score_real - MAX_BONUS) / D2_EXPONENT_DENOMINATOR)
-        self.data['bonus_raw'] = (self.coeff * (self.data['D1'] + self.data['D2'])).astype('int')
+        self.data['bonus_raw'] = (self.coeff * (self.data['D1'] + self.data['D2'])).astype('float64')
         self.data['bonus'] = self.data.bonus_raw
         self.data.loc[self.data.heredity & (self.data.n_legs >= MIN_LEGIONNAIRES_TO_REDUCE_BONUS), 'bonus'] *= \
             (2 / self.data[self.data.heredity & (self.data.n_legs >= MIN_LEGIONNAIRES_TO_REDUCE_BONUS)]['n_legs'])

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -30,8 +30,8 @@ class TestReleases(unittest.TestCase):
 
         team_at_place_57 = Team_rating.objects.filter(release=self.release).order_by("place")[56]
         self.assertEqual(65268, team_at_place_57.team_id)
-        self.assertEqual(7653, team_at_place_57.rating)
-        self.assertEqual(-82, team_at_place_57.rating_change)
+        self.assertEqual(7652, team_at_place_57.rating)
+        self.assertEqual(-83, team_at_place_57.rating_change)
         self.assertEqual(7962, team_at_place_57.trb)
         self.assertEqual(8, team_at_place_57.place_change)
         self.assertEqual(57, team_at_place_57.place)
@@ -78,7 +78,7 @@ class TestReleases(unittest.TestCase):
         self.assertEqual(1, first_place.mp)
         self.assertEqual(49804, first_place.team_id)
         self.assertEqual(2079, first_place.rating)
-        self.assertEqual(79, first_place.rating_change)
+        self.assertEqual(80, first_place.rating_change)
         self.assertEqual(2079, first_place.bp)
         self.assertEqual(0, first_place.d1)
         self.assertEqual(160, first_place.d2)


### PR DESCRIPTION
Addresses two warnings from pandas. One of these changes led to fixing a bug.

`.astype('int')` does not round properly and instead simply cuts off values (e.g., from 64.6 to 64). Because of that, we were using wrong values for tournament bonuses, mostly lower ones (by 1). After more than two years the difference is notable for top teams (from 5 to 15 points in the top 20).