### PR TITLE
reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@ fly.toml
 .env
 *.log
 .DS_Store
+venv/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ COPY requirements.txt /tmp/requirements.txt
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl
+    apt-get install -y curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN set -ex && \
     pip install --upgrade pip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-bookworm
+ARG PYTHON_VERSION=3.12-slim-bookworm
 
 FROM python:${PYTHON_VERSION}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pytz==2023.3.post1
 six==1.16.0
 sqlparse==0.4.4
 python-dotenv==1.0.0
-mmh3==3.1.0
+mmh3==4.1.0
 numpy==1.26.1


### PR DESCRIPTION
The main change is the switch to slim-bookworm (we don’t need gcc and related packages for newer versions of mmh3 which with pre-built wheels for more platforms). Overall, this reduced the size of an image from 1.6 GB to 532 MB.