### PR TITLE
ignore .venv as well in docker image building

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,4 @@ fly.toml
 *.log
 .DS_Store
 venv/
-
+.venv/


### PR DESCRIPTION
Follow-up to https://github.com/maii-chgk/rating-b/pull/109. Actual size is 359 MB.