### PR TITLE
address copy-on-write-related warnings

### DIFF
--- a/scripts/teams.py
+++ b/scripts/teams.py
@@ -103,7 +103,7 @@ class TeamRating:
         new_teams["trb"] = new_teams.baseTeamMembers.map(
             lambda x: player_rating.calc_rt(x, self.q)
         )
-        new_teams["trb"].fillna(0, inplace=True)
+        new_teams.fillna({"trb": 0}, inplace=True)
         new_teams["rating"] = new_teams["trb"] * NEW_TEAMS_LOWERING_COEFFICIENT
         new_teams["prev_rating"] = None
         new_teams["prev_place"] = None
@@ -111,4 +111,4 @@ class TeamRating:
 
     def calc_trb(self, player_rating: PlayerRating):
         self.data["trb"] = player_rating.calc_tech_rating_all_teams(q=self.q)
-        self.data["trb"].fillna(0, inplace=True)
+        self.data.fillna({"trb": 0}, inplace=True)


### PR DESCRIPTION
pandas is moving to a copy-on-write model.

From their guide:

> CoW means that any DataFrame or Series derived from another in any way always behaves as a copy. As a consequence, we can only change the values of an object through modifying the object itself.

Thus, `new_teams["trb"].fillna(0, inplace=True)` would not work with CoW (trb would be filled with zeroes only in a copy, not in the original `new_teams` dataframe).

This can be addressed by using a slightly different syntax for in-place updates.

Migration guide: https://pandas.pydata.org/docs/dev/user_guide/copy_on_write.html#copy-on-write-migration-guide