### PR TITLE
use COPY for writing into larger tables

### DIFF
--- a/copy-performance-findings.md
+++ b/copy-performance-findings.md
@@ -1,0 +1,145 @@
+# COPY vs INSERT: performance findings
+
+Investigation into why switching the large-table writes from multi-row `INSERT`
+to `COPY` (commit `0a35dbe`) only moved a full release calc from ~80s to
+~50–60s instead of something more dramatic.
+
+## Setup
+
+- Run against a backup of the production DB in Docker (`postgres:17`, `localhost:5432`).
+- Profiled a single `calc_release` for **2026-06-11** (release id 442).
+- Hot tables for that release:
+  - `player_rating_by_tournament` — **300,784 rows**
+  - `player_rating` — **73,021 rows**
+  - `team_rating` — 3,038 rows
+  - `tournament_in_release` — 11 rows
+
+## Headline conclusion
+
+`COPY` only removes the *statement parsing / multi-row `VALUES` building /
+network round-trip* overhead. That was a **minority** of the cost. The two
+things that actually dominate a release calc are untouched by the write method:
+
+1. **`copy.deepcopy` of the pandas DataFrames** in the pure-Python calc phase.
+2. **Dead-tuple unique-index visibility checks** during the write, caused by the
+   `DELETE … where release_id = X` + reinsert-same-keys pattern inside one
+   transaction. This per-row server-side cost is **identical for `COPY` and
+   `INSERT`**.
+
+That is why the gain was modest.
+
+## Experiment 1 — full `calc_release` breakdown (42.6s total)
+
+cProfile + per-table timing of one release calc:
+
+| Phase | Time | Notes |
+|---|---|---|
+| `make_step_for_teams_and_players` | **18.8s** | of which **`copy.deepcopy` = 18.2s** (11M `deepcopy` calls deep-copying the team/player DataFrames element by element, `scripts/main.py:59-60`) |
+| `save_player_rating_by_tournament` (300k rows) | **12.5s** | build CSV 2.3s + `copy_expert` 10.2s (table was bloated, see Exp. 2/3) |
+| `PlayerRating.__init__` (reads initial data) | 4.4s | DB read, not a write |
+| `save_player_rating` (73k rows) | 4.2s | build CSV 3.7s + `copy_expert` 0.5s |
+| `save_team_ratings` (3k rows) | 0.27s | |
+| commit (deferred FK check) + misc | ~2s | variable |
+
+The deepcopy and the `player_rating_by_tournament` write together are ~30s of
+the 42.6s. Neither is helped by `COPY`.
+
+> Note: release 442 happened to have **0 tournaments**, so `tournament_result`
+> writes were not exercised in this profile. A release with tournaments adds
+> `dump_team_bonuses_for_tournament` cost on top, with the same DELETE+reinsert
+> characteristics.
+
+## Experiment 2 — where the write cost actually is
+
+Isolated `COPY` of the same 300,784 `player_rating_by_tournament` rows under
+different conditions:
+
+| Scenario | Time |
+|---|---|
+| `COPY` into empty heap table, **no indexes** | **0.13s** |
+| `COPY` into empty table **with its 3 indexes** | **1.2s** |
+| Server-side `COPY FROM '/tmp/file'` (with indexes) | 1.18s |
+| `copy_expert` from a Python `StringIO` into empty indexed table | 1.2s |
+| `COPY` after `DELETE` of the same keys, **same transaction** (current code, bloated table) | **6.1s** |
+| Old multi-row `INSERT` (batch 5000) after the same `DELETE`, same transaction | **5.8s** |
+
+Reads:
+
+- **Index maintenance** alone takes the write from 0.13s → 1.2s (~9×). The table
+  has three indexes (see below).
+- **`copy_expert` streaming from Python is not the bottleneck** — into an empty
+  indexed table it matches a server-side `COPY FROM` file (~1.2s). Raising the
+  read buffer (`size=1<<20`) made no difference.
+- **The DELETE+reinsert-in-one-transaction pattern is the bottleneck**: 6.1s,
+  ~5× slower than loading into an empty indexed table.
+- **`COPY` (6.1s) ≈ old `INSERT` (5.8s)** in that pattern. The cost is
+  server-side and method-independent, which is the core reason `COPY` didn't
+  help here.
+
+### Why DELETE+reinsert in one transaction is slow
+
+The unique index `(release_id, player_id, tournament_id)` still contains the
+entries for the just-deleted rows (they're dead but uncommitted, so not
+vacuumable yet). Every newly inserted row whose key matches a deleted one must do
+a uniqueness check that walks those dead index entries and performs heap
+visibility lookups. With a full key overlap (every release_id key is deleted then
+re-inserted), this happens for all 300k rows.
+
+## Experiment 3 — DELETE mitigations (none give a clean win)
+
+Tested on a less-bloated table state (hence lower baseline numbers — the penalty
+scales with bloat, see below):
+
+| Approach | Result |
+|---|---|
+| `DELETE` + `COPY` in same txn (current) | ~2.7s |
+| `DELETE`; **`COMMIT`**; then `COPY` in a fresh txn | ~3.2s — **no improvement** |
+| `DELETE`; `COMMIT`; **`VACUUM`** (15.6s); `COPY` | COPY ~3.0s, but VACUUM costs 15.6s — **net loss** for a few-release run |
+
+- Committing the DELETE before the write does **not** remove the penalty.
+- `VACUUM` removes the dead tuples and helps the COPY, but a full-table vacuum
+  costs far more than it saves when only a few releases are being recalculated.
+- **The penalty scales with bloat.** A freshly-vacuumed table gives ~2.7s for
+  the write; after repeated recalc cycles without vacuum it climbs to ~6s. Since
+  the cron reruns every 3 hours and only ever deletes+reinserts (no truncate),
+  the table stays perpetually somewhat bloated.
+
+## Index cost summary
+
+`player_rating_by_tournament` carries:
+
+- `PRIMARY KEY (id)` (fillfactor 80)
+- `UNIQUE (release_id, player_id, tournament_id)` (fillfactor 80)
+- `btree (player_id)` (fillfactor 80)
+- `FOREIGN KEY (release_id) → release(id)` — `DEFERRABLE INITIALLY DEFERRED`
+  (checked at COMMIT, not during the COPY)
+
+Effects:
+
+- Maintaining these three indexes turns a 0.13s heap-only load into a 1.2s load.
+- The **unique index is what makes DELETE+reinsert expensive** (dead-entry
+  visibility checks).
+- The deferred FK is checked once at COMMIT; its cost showed up as a ~1s commit
+  in one profile and ~0 in another (variable).
+
+## Other findings
+
+- **`copy.deepcopy` is the single largest cost** in a release calc (~18s),
+  entirely in the pure-Python calc phase (`scripts/main.py:59-60`). It is
+  unrelated to the write strategy. Replacing it with a vectorized pandas `.copy()`
+  (or restructuring to avoid the deep copy) is the biggest available lever.
+
+- **Unchanged releases still pay the full delete+reinsert.** Recalculating
+  release 442 produced a hash that **matched** the stored one (the
+  `"hashes are different, updating release"` log line never fired), yet
+  `dump_release` had already deleted and reinserted ~300k + ~73k byte-identical
+  rows. The existing `calculate_hash` fingerprint is only consulted *after* the
+  write, to decide whether to bump `updated_at` — never to skip the write.
+  For the real workload (recalc the last few releases every 3 hours, where recent
+  releases usually have not changed), short-circuiting the write when the hash
+  matches would eliminate most of this cost without touching the schema or the
+  read path.
+  - Caveat: the current hash covers player/team/tournament ratings but not every
+    written column (`rating_change`, `place`, `place_change`, bonus detail), so a
+    skip-on-match would want the hash widened or accept that purely cosmetic
+    column drift would not be re-persisted.

--- a/scripts/db_tools.py
+++ b/scripts/db_tools.py
@@ -1,5 +1,8 @@
+import csv
 import datetime
-from typing import Dict, List, Iterable
+import io
+import math
+from typing import Dict, List, Iterable, Sequence
 from django.db.models import F, Q
 from django.db import connection
 import logging
@@ -41,6 +44,68 @@ def fast_insert(table: str, data: Iterable[dict], batch_size: int = 5000):
         if batch:
             values = ",\n".join(f"({','.join(str(row[column]) for column in columns)})" for row in batch)
             cursor.execute(f"INSERT INTO {SCHEMA_NAME}.{table} ({columns_joined}) VALUES {values}")
+
+
+def fast_copy(
+    table: str,
+    data: Iterable[dict],
+    columns: Sequence[str],
+    chunk_size: int = 100_000,
+):
+    """
+    Bulk-loads rows into {SCHEMA_NAME}.{table} via PostgreSQL COPY FROM STDIN.
+
+    `columns` is the explicit list of columns to write; each row in `data` is a
+    dict whose keys include those columns. None values become SQL NULL.
+    Booleans are emitted as `true`/`false`. The CSV stream uses an unquoted
+    empty field for NULL (`NULL ''`), so this helper is only safe for tables
+    whose target columns are not text/varchar where empty string is a valid
+    value distinct from NULL.
+    """
+    columns_joined = ", ".join(columns)
+    copy_sql = (
+        f"COPY {SCHEMA_NAME}.{table} ({columns_joined}) "
+        "FROM STDIN WITH (FORMAT csv, NULL '')"
+    )
+
+    def flush(buf: io.StringIO):
+        if buf.tell() == 0:
+            return
+        buf.seek(0)
+        with connection.cursor() as cursor:
+            cursor.copy_expert(copy_sql, buf)
+
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    rows_in_buf = 0
+    for row in data:
+        writer.writerow(_render_csv_cell(row.get(column)) for column in columns)
+        rows_in_buf += 1
+        if rows_in_buf >= chunk_size:
+            flush(buf)
+            buf = io.StringIO()
+            writer = csv.writer(buf)
+            rows_in_buf = 0
+    flush(buf)
+
+
+def _render_csv_cell(value):
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, float):
+        if math.isnan(value):
+            return ""
+        # COPY parses integer columns strictly: "1509.0" is rejected even though
+        # INSERT VALUES would auto-cast it. Pandas promotes int columns to float
+        # whenever the column contains a NaN, so we render whole-valued floats
+        # as ints to keep round-trip compatibility.
+        as_float = float(value)
+        if as_float.is_integer():
+            return str(int(as_float))
+        return repr(as_float)
+    return value
 
 
 def get_season(release_date: datetime.date) -> models.Season:

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -113,61 +113,73 @@ def delete_previous_results(release_id):
 
 
 def save_player_rating(release_id: int, player_rating: PlayerRating):
+    columns = ["release_id", "player_id", "rating", "rating_change", "place"]
     player_ratings = (
         {
             "release_id": release_id,
             "player_id": player_id,
-            "rating": player["rating"],
-            "rating_change": ((player["rating"] - player["prev_rating"]) if player["prev_rating"] else "NULL"),
+            "rating": round(player["rating"]),
+            "rating_change": (round(player["rating"] - player["prev_rating"]) if player["prev_rating"] else None),
             "place": player["place"],
         }
         for player_id, player in player_rating.data.iterrows()
         if player["rating"] > 0
     )
-    db_tools.fast_insert("player_rating", player_ratings)
+    db_tools.fast_copy("player_rating", player_ratings, columns)
 
 
 def save_team_ratings(release_id: int, teams: pd.DataFrame):
+    columns = ["release_id", "team_id", "rating", "trb", "rating_change", "place", "place_change"]
     team_ratings = (
         {
             "release_id": release_id,
             "team_id": team_id,
-            "rating": team["rating"],
-            "trb": team["trb"],
-            "rating_change": ((team["rating"] - team["prev_rating"]) if team["prev_rating"] else "NULL"),
-            "place": team["place"] or "NULL",
-            "place_change": ((decimal.Decimal(team["place"]) - team["prev_place"]) if team["prev_place"] else "NULL"),
+            "rating": round(team["rating"]),
+            "trb": round(team["trb"]),
+            "rating_change": (round(team["rating"] - team["prev_rating"]) if team["prev_rating"] else None),
+            "place": team["place"] or None,
+            "place_change": ((decimal.Decimal(team["place"]) - team["prev_place"]) if team["prev_place"] else None),
         }
         for team_id, team in teams.iterrows()
     )
-    db_tools.fast_insert("team_rating", team_ratings)
+    db_tools.fast_copy("team_rating", team_ratings, columns)
 
 
 def save_player_rating_by_tournament(release_id: int, player_rating: PlayerRating):
+    columns = [
+        "release_id",
+        "player_id",
+        "tournament_result_id",
+        "tournament_id",
+        "initial_score",
+        "weeks_since_tournament",
+        "cur_score",
+    ]
+    active_bonuses = player_rating.data.loc[player_rating.data["rating"] != 0, "top_bonuses"]
     bonuses = (
         {
             "release_id": release_id,
             "player_id": player_id,
-            "tournament_result_id": rating_by_trnmt.tournament_result_id or "NULL",
-            "tournament_id": rating_by_trnmt.tournament_id or "NULL",
-            "initial_score": rating_by_trnmt.initial_score,
+            "tournament_result_id": rating_by_trnmt.tournament_result_id or None,
+            "tournament_id": rating_by_trnmt.tournament_id or None,
+            "initial_score": round(rating_by_trnmt.initial_score) if rating_by_trnmt.initial_score is not None else None,
             "weeks_since_tournament": rating_by_trnmt.weeks_since_tournament,
-            "cur_score": rating_by_trnmt.cur_score,
+            "cur_score": round(rating_by_trnmt.cur_score),
         }
-        for player_id, player in player_rating.data.iterrows()
-        if player["rating"] != 0
-        for rating_by_trnmt in player["top_bonuses"]
+        for player_id, top_bonuses in active_bonuses.items()
+        for rating_by_trnmt in top_bonuses
     )
-    db_tools.fast_insert("player_rating_by_tournament", bonuses)
+    db_tools.fast_copy("player_rating_by_tournament", bonuses, columns)
 
 
 def save_tournaments_in_release(release_id: int, tournaments: Iterable[trnmt.Tournament]):
+    columns = ["release_id", "tournament_id"]
     tournaments_in_release = (
         {"release_id": release_id, "tournament_id": tournament.id}
         for tournament in tournaments
         if tournament.is_in_maii_rating
     )
-    db_tools.fast_insert("tournament_in_release", tournaments_in_release)
+    db_tools.fast_copy("tournament_in_release", tournaments_in_release, columns)
 
 
 # Saves tournament bonuses that were already calculated.
@@ -175,26 +187,42 @@ def dump_team_bonuses_for_tournament(trnmt: trnmt.Tournament):
     with connection.cursor() as cursor:
         cursor.execute(f"delete from {SCHEMA_NAME}.tournament_result where tournament_id = {trnmt.id}")
 
-    tournament_results = [
+    columns = [
+        "tournament_id",
+        "team_id",
+        "mp",
+        "bp",
+        "m",
+        "rating",
+        "d1",
+        "d2",
+        "rating_change",
+        "r",
+        "rt",
+        "rb",
+        "rg",
+        "is_in_maii_rating",
+    ]
+    tournament_results = (
         {
             "tournament_id": trnmt.id,
             "team_id": team["team_id"],
             "mp": team["expected_place"],
-            "bp": team["score_pred"],
+            "bp": round(team["score_pred"]),
             "m": team["position"],
-            "rating": team["score_real"],
-            "d1": team["D1"],
-            "d2": team["D2"],
-            "rating_change": team["bonus"],
-            "r": team["r"],
-            "rt": team["rt"],
-            "rb": team["rb"],
-            "rg": team["rg"],
-            "is_in_maii_rating": "TRUE" if team["heredity"] else "FALSE",
+            "rating": round(team["score_real"]),
+            "d1": round(team["D1"]),
+            "d2": round(team["D2"]),
+            "rating_change": round(team["bonus"]),
+            "r": round(team["r"]),
+            "rt": round(team["rt"]),
+            "rb": round(team["rb"]),
+            "rg": round(team["rg"]),
+            "is_in_maii_rating": bool(team["heredity"]),
         }
         for _, team in trnmt.data.iterrows()
-    ]
-    db_tools.fast_insert("tournament_result", tournament_results)
+    )
+    db_tools.fast_copy("tournament_result", tournament_results, columns)
 
 
 def dump_rating_for_next_release(old_release: models.Release, teams_with_updated_rating: List[Tuple[int, int]]):
@@ -306,6 +334,12 @@ def calc_all_releases(first_to_calc: datetime.date, last_to_calc: datetime.date 
     n_releases_calculated = 0
     last_day_to_calc = last_to_calc + datetime.timedelta(days=7)
     while next_release_date <= last_day_to_calc:
+        # Each release has a multi-minute pure-Python calc phase during which the
+        # DB connection sits idle; intermediate NAT/firewall/pooler hops can drop
+        # the TCP socket and the subsequent COPY then fails with "server closed
+        # the connection unexpectedly". Force a fresh connection per release so
+        # the long idle stretch never matters.
+        connection.close()
         calc_release(next_release_date=next_release_date)
         n_releases_calculated += 1
         next_release_date += datetime.timedelta(days=7)


### PR DESCRIPTION
Writing player ratings by tournament takes about 80 seconds in production. We would like to do this faster, and potentially scale down the database machine. We will start by using `COPY` instead of `INSERT` and see if that would be enough.