### PR TITLE
filter out duplicate players from tournaments

### DIFF
--- a/scripts/tournament.py
+++ b/scripts/tournament.py
@@ -1,7 +1,9 @@
 import pandas as pd
 import numpy as np
 import logging
-from typing import Any, Tuple, Set, List, Dict
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple, Set, List, Dict
 import numpy.typing as npt
 from .constants import (
     D2_MULTIPLIER,
@@ -23,6 +25,13 @@ logger = logging.getLogger(__name__)
 
 class EmptyTournamentException(Exception):
     pass
+
+
+@dataclass(frozen=True)
+class RosterEntry:
+    team_id: int
+    player_id: int
+    flag: Optional[str]
 
 
 class Tournament:
@@ -58,10 +67,20 @@ class Tournament:
         if any(team["position"] > len(teams) for team in teams.values()):
             raise EmptyTournamentException("There are teams with impossible positions")
 
-        for team_player in trnmt_from_db.roster_set.all():
+        rosters = list(trnmt_from_db.roster_set.all())
+        chosen_team_by_player = self.deduplicate_rosters(
+            [RosterEntry(tp.team_id, tp.player_id, tp.flag) for tp in rosters if tp.team_id in teams]
+        )
+        for team_player in rosters:
             if team_player.team_id not in teams:
                 logger.debug(
                     f"Tournament {self.id}, team {team_player.team_id}: player {team_player.player_id} is in roster but the team did not play there!"
+                )
+                continue
+            if chosen_team_by_player[team_player.player_id] != team_player.team_id:
+                logger.debug(
+                    f"Tournament {self.id}: player {team_player.player_id} rostered on multiple teams; "
+                    f"keeping team {chosen_team_by_player[team_player.player_id]}, dropping from team {team_player.team_id}"
                 )
                 continue
             teams[team_player.team_id]["teamMembers"].append(team_player.player_id)
@@ -166,6 +185,23 @@ class Tournament:
         if ttype in models.TRNMT_TYPES:
             return SYNCHRONOUS_TOURNAMENT_COEFFICIENT
         raise Exception(f"tournament type {ttype} is not supported!")
+
+    @staticmethod
+    def deduplicate_rosters(roster_entries: List[RosterEntry]) -> Dict[int, int]:
+        """Map each player_id to the single team_id they count for in this tournament.
+
+        A player rostered on several teams is kept on the base ("Б") team;
+        if the flag ties (several base teams, or none), the smallest team_id wins.
+        """
+        entries_by_player: Dict[int, List[RosterEntry]] = defaultdict(list)
+        for entry in roster_entries:
+            entries_by_player[entry.player_id].append(entry)
+
+        chosen: Dict[int, int] = {}
+        for player_id, entries in entries_by_player.items():
+            base_team_ids = sorted(entry.team_id for entry in entries if entry.flag == "Б")
+            chosen[player_id] = base_team_ids[0] if base_team_ids else min(entry.team_id for entry in entries)
+        return chosen
 
     @staticmethod
     def adjust_for_missing_rosters(teams_without_rosters: List[int], teams: Dict):

--- a/tests/test_roster_deduplication.py
+++ b/tests/test_roster_deduplication.py
@@ -1,0 +1,76 @@
+import unittest
+from dotenv import load_dotenv
+
+load_dotenv("../.env.test")
+
+import django
+
+django.setup()
+
+from scripts.tournament import RosterEntry, Tournament
+
+
+class TestRosterDeduplication(unittest.TestCase):
+    def test_single_team_unchanged(self):
+        chosen = Tournament.deduplicate_rosters(
+            [RosterEntry(10, 1, "Б"), RosterEntry(20, 2, "Л")]
+        )
+        self.assertEqual({1: 10, 2: 20}, chosen)
+
+    def test_base_team_kept(self):
+        chosen = Tournament.deduplicate_rosters(
+            [RosterEntry(10, 1, "Б"), RosterEntry(20, 1, "Л")]
+        )
+        self.assertEqual({1: 10}, chosen)
+
+    def test_base_team_kept_regardless_of_order(self):
+        chosen = Tournament.deduplicate_rosters(
+            [RosterEntry(20, 1, "Л"), RosterEntry(10, 1, "Б")]
+        )
+        self.assertEqual({1: 10}, chosen)
+
+    def test_base_team_kept_when_base_has_larger_id(self):
+        chosen = Tournament.deduplicate_rosters(
+            [RosterEntry(10, 1, "Л"), RosterEntry(20, 1, "Б")]
+        )
+        self.assertEqual({1: 20}, chosen)
+
+    def test_two_base_teams_smallest_id(self):
+        chosen = Tournament.deduplicate_rosters(
+            [RosterEntry(20, 1, "Б"), RosterEntry(10, 1, "Б")]
+        )
+        self.assertEqual({1: 10}, chosen)
+
+    def test_two_legionnaire_teams_smallest_id(self):
+        chosen = Tournament.deduplicate_rosters(
+            [RosterEntry(20, 1, "Л"), RosterEntry(10, 1, "Л")]
+        )
+        self.assertEqual({1: 10}, chosen)
+
+    def test_null_flags_smallest_id(self):
+        chosen = Tournament.deduplicate_rosters(
+            [RosterEntry(20, 1, None), RosterEntry(10, 1, None)]
+        )
+        self.assertEqual({1: 10}, chosen)
+
+    def test_three_teams_one_base(self):
+        chosen = Tournament.deduplicate_rosters(
+            [RosterEntry(10, 1, "Л"), RosterEntry(30, 1, "Б"), RosterEntry(20, 1, "Л")]
+        )
+        self.assertEqual({1: 30}, chosen)
+
+    def test_mix_of_duplicated_and_unique_players(self):
+        chosen = Tournament.deduplicate_rosters(
+            [
+                RosterEntry(10, 1, "Б"),
+                RosterEntry(20, 1, "Л"),
+                RosterEntry(20, 2, "Б"),
+                RosterEntry(30, 3, "Л"),
+                RosterEntry(40, 3, "Л"),
+            ]
+        )
+        self.assertEqual({1: 10, 2: 20, 3: 30}, chosen)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A fair amount (122) tournaments have one player in two team rosters. This will get addressed at the source as well, but we need to be ready for this and not crash when it happens (we have a `unique` index on the `player_rating_by_tournament` table).

We will do this with a deterministic rule: if only one entry is for a base team, we keep it and drop others; if there are no base team (or more than one), we keep the entry with the smallest team_id.